### PR TITLE
Converting range type to list

### DIFF
--- a/rotation_forest/rotation_forest.py
+++ b/rotation_forest/rotation_forest.py
@@ -57,7 +57,7 @@ class RotationTreeClassifier(DecisionTreeClassifier):
     def pca_algorithm(self):
         """ Deterimine PCA algorithm to use. """
         if self.rotation_algo == 'randomized':
-            return PCA(svd_solver=randomized, random_state=self.random_state)
+            return PCA(svd_solver='randomized', random_state=self.random_state)
         elif self.rotation_algo == 'pca':
             return PCA()
         else:

--- a/rotation_forest/rotation_forest.py
+++ b/rotation_forest/rotation_forest.py
@@ -10,7 +10,7 @@ from sklearn.decomposition import PCA
 def random_feature_subsets(array, batch_size, random_state=1234):
     """ Generate K subsets of the features in X """
     random_state = check_random_state(random_state)
-    features = range(array.shape[1])
+    features = list(range(array.shape[1]))
     random_state.shuffle(features)
     for batch in gen_batches(len(features), batch_size):
         yield features[batch]


### PR DESCRIPTION
When executing Rotation Forest Classifier with python3.7, I encountered the following error:

Traceback (most recent call last):
...
...
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/rotation_forest/rotation_forest.py", line 15, in random_feature_subsets
    random_state.shuffle(features)
  File "mtrand.pyx", line 4859, in mtrand.RandomState.shuffle
  File "mtrand.pyx", line 4862, in mtrand.RandomState.shuffle
TypeError: 'range' object does not support item assignment.

This small modification fixes the problem.